### PR TITLE
fix: Resolve React 19 TypeScript compatibility issues

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -78,7 +78,7 @@ const GatsbyImageHydrator: FC<GatsbyImageProps> = function GatsbyImageHydrator({
     className: wClass,
     ...wrapperProps
   } = getWrapperProps(width, height, layout)
-  const root = useRef<HTMLElement>()
+  const root = useRef<HTMLElement>(null)
   const cacheKey = useMemo(() => JSON.stringify(image.images), [image.images])
 
   // Preact uses class instead of className so we need to check for both

--- a/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.server.tsx
@@ -4,7 +4,7 @@ import { Placeholder } from "./placeholder"
 import { MainImage, MainImageProps } from "./main-image"
 import { LayoutWrapper } from "./layout-wrapper"
 import PropTypes from "prop-types"
-import type { FunctionComponent, WeakValidationMap } from "react"
+import type { FunctionComponent } from "react"
 import type { GatsbyImageProps, IGatsbyImageData } from "./gatsby-image.browser"
 
 const removeNewLines = (str: string): string => str.replace(/\n/g, ``)
@@ -140,4 +140,4 @@ export const altValidator: PropTypes.Validator<string> = (
 export const propTypes = {
   image: PropTypes.object.isRequired,
   alt: altValidator,
-} as WeakValidationMap<GatsbyImageProps>
+}


### PR DESCRIPTION
Fix TypeScript errors in gatsby-plugin-image for React 19:

1. Remove WeakValidationMap import and usage
   - WeakValidationMap was removed from React 19's public API
   - Remove type annotation from propTypes export

2. Fix useRef initialization
   - React 19 TypeScript requires initial value for useRef
   - Change useRef<HTMLElement>() to useRef<HTMLElement>(null)

These changes maintain backward compatibility with React 18 while ensuring TypeScript compilation works with React 19.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
