### PR TITLE
Fix React 19 compatibility in gatsby-react-router-scroll tests

### DIFF
--- a/packages/gatsby-react-router-scroll/src/__tests__/use-scroll-restoration.tsx
+++ b/packages/gatsby-react-router-scroll/src/__tests__/use-scroll-restoration.tsx
@@ -8,7 +8,7 @@ import {
   History,
   createMemorySource,
   createHistory,
-} from "@reach/router"
+} from "@gatsbyjs/reach-router"
 import { render, fireEvent } from "@testing-library/react"
 import { useScrollRestoration } from "../use-scroll-restoration"
 import { ScrollHandler } from "../scroll-handler"


### PR DESCRIPTION
- Update import from @reach/router to @gatsbyjs/reach-router in test file
- Resolves TypeScript JSX component type errors with LocationProvider
- Ensures compatibility with React 19's stricter type checking

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
