### PR TITLE
feat: Update Node.js requirement to 20.0.0 for React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "engines": {
     "yarn": "^1.17.3",
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=8.0.0"
   },
   "eslintIgnore": [
@@ -130,6 +130,7 @@
   ],
   "resolutions": {
     "@babel/plugin-transform-modules-commonjs": "7.18.6",
-    "minimatch": "^9.0.5"
+    "minimatch": "^9.0.5",
+    "**/minimatch": "^9.0.5"
   }
 }

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -43,5 +43,8 @@
   "author": "Matt Kane <matt@gatsbyjs.com>",
   "dependencies": {
     "@babel/runtime": "^7.20.13"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -101,6 +101,6 @@
     "postinstall": "node scripts/postinstall.js"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/gatsby-dev-cli/package.json
+++ b/packages/gatsby-dev-cli/package.json
@@ -48,6 +48,9 @@
     "watch": "babel -w src --out-dir dist --ignore \"**/__tests__\""
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
+  },
+  "resolutions": {
+    "minimatch": "^9.0.5"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -214,7 +214,7 @@
     "gatsby-sharp": "^1.15.0-next.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "adapters.js",


### PR DESCRIPTION
- Update root package.json to require Node.js >=20.0.0
- Update gatsby, gatsby-cli, gatsby-dev-cli, and create-gatsby packages to require Node.js >=20.0.0
- This resolves compatibility issues with dependencies like minimatch@10.0.3 that require Node.js 20+
- Ensures React 19 support works properly in all environments including CI

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
